### PR TITLE
Add Further Mock Debug

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -485,7 +485,7 @@ func (a *APITest) runTest() (*httptest.ResponseRecorder, *http.Request) {
 		}
 	}
 
-	a.request.handler.ServeHTTP(res, req)
+	a.serveHttp(res, req)
 
 	if a.debugEnabled {
 		responseDump, err := httputil.DumpResponse(res.Result(), true)
@@ -495,6 +495,16 @@ func (a *APITest) runTest() (*httptest.ResponseRecorder, *http.Request) {
 	}
 
 	return res, req
+}
+
+func (a *APITest) serveHttp(res *httptest.ResponseRecorder, req *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			a.t.Fatal(err)
+		}
+	}()
+
+	a.request.handler.ServeHTTP(res, req)
 }
 
 func (a *APITest) BuildRequest() *http.Request {

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -49,7 +49,7 @@ func Equal(t *testing.T, expected, actual interface{}, message ...string) {
 		if len(message) > 0 {
 			t.Fatalf(strings.Join(message, ", "))
 		} else {
-			t.Fatalf("Expected %+v but recevied %+v", expected, actual)
+			t.Fatalf("Expected '%+v' but recevied '%+v'", expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
@steinfletcher Resolves issue #16 to some extent. Will add further reporting as a second pass once we're happy with this.

Update the mocks code to how each mock matcher failure as output when an error occurs during the serveHttp phase of testing.