### PR TITLE
Support r.URL.Host in host matcher

### DIFF
--- a/mocks.go
+++ b/mocks.go
@@ -398,6 +398,9 @@ var pathMatcher Matcher = func(r *http.Request, spec *MockRequest) error {
 
 var hostMatcher Matcher = func(r *http.Request, spec *MockRequest) error {
 	receivedHost := r.Host
+	if receivedHost == "" {
+		receivedHost = r.URL.Host
+	}
 	mockHost := spec.url.Host
 	if mockHost == "" {
 		return nil


### PR DESCRIPTION
Previously, only r.Host from the incoming request was used to match
the expected mock host. This change supports r.URL.Host if r.Host
is not present.

Go http client docs specifies that both are valid:

```
For client requests Host optionally overrides the Host
header to send. If empty, the Request.Write method uses
the value of URL.Host. Host may contain an international
domain name.
```