### PR TITLE
Adds custom matching functions to mocks

### DIFF
--- a/examples/mocks/api_test.go
+++ b/examples/mocks/api_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"github.com/steinfletcher/apitest"
 	"net/http"
 	"testing"
@@ -20,6 +21,13 @@ func TestGetUser_Success(t *testing.T) {
 
 var getPreferencesMock = apitest.NewMock().
 	Get("/preferences/12345").
+	AddMatcher(func(r *http.Request, mr *apitest.MockRequest) error {
+		// Custom matching func for URL Scheme
+		if r.URL.Scheme != "http" {
+			return errors.New("request did not have 'http' scheme")
+		}
+		return nil
+	}).
 	RespondWith().
 	Body(`{"is_contactable": true}`).
 	Status(http.StatusOK).


### PR DESCRIPTION
This PR adds the ability to add custom matcher functions to mocks using the AddMatcher method on the MockRequest type.