### PR TITLE
trim host from diagram lines

### DIFF
--- a/diagram.go
+++ b/diagram.go
@@ -136,11 +136,15 @@ var templateFunc = &template.FuncMap{
 	},
 }
 
-func truncate(s string) string {
-	if len(s) > 50 {
-		return fmt.Sprintf("%s...", s[:50])
+func formatDiagramRequest(req *http.Request) string {
+	out := req.URL.Path
+	if req.URL.RawQuery != "" {
+		out = fmt.Sprintf("%s %s?%s", req.Method, out, req.URL.RawQuery)
 	}
-	return s
+	if len(out) > 65 {
+		return fmt.Sprintf("%s...", out[:65])
+	}
+	return out
 }
 
 func badgeCSSClass(status int) string {
@@ -164,7 +168,7 @@ func NewHTMLTemplateModel(r *Recorder) (HTMLTemplateModel, error) {
 		switch v := event.(type) {
 		case HttpRequest:
 			httpReq := v.Value
-			webSequenceDiagram.AddRequestRow(v.Source, v.Target, truncate(fmt.Sprintf("%s %s", httpReq.Method, httpReq.URL)))
+			webSequenceDiagram.AddRequestRow(v.Source, v.Target, formatDiagramRequest(httpReq))
 			entry, err := NewHttpRequestLogEntry(httpReq)
 			if err != nil {
 				return HTMLTemplateModel{}, err

--- a/diagram_test.go
+++ b/diagram_test.go
@@ -110,6 +110,7 @@ func TestNewHTMLTemplateModel_Success(t *testing.T) {
 	assert.Equal(t, template.JS(`{"host":"example.com","method":"GET","name":"some test","path":"/user"}`), model.MetaJSON)
 	assert.Equal(t, http.StatusNoContent, model.StatusCode)
 	assert.Equal(t, "badge badge-success", model.BadgeClass)
+	assert.Contains(t, model.WebSequenceDSL, "GET /abcdef")
 }
 
 func aRecorder() *Recorder {
@@ -174,7 +175,7 @@ func TestNewHttpResponseLogEntry_PlainText(t *testing.T) {
 }
 
 func aRequest() HttpRequest {
-	req := httptest.NewRequest(http.MethodGet, "http://example.com/abcdef", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/abcdef?name=abc", nil)
 	req.Header.Set("Content-Type", "application/json")
 	return HttpRequest{Value: req, Source: "reqSource", Target: "reqTarget"}
 }

--- a/template.go
+++ b/template.go
@@ -39,7 +39,7 @@ const Template = `<!DOCTYPE html>
             <th scope="row">{{ inc $i }}</th>
             <td>
 <pre>{{ $e.Header }}</pre>
-{{if $e.Body }}<pre><code>{{ $e.Body }}</code></pre>{{end}}
+{{if $e.Body }}<pre style="max-height: 1000px;"><code>{{ $e.Body }}</code></pre>{{end}}
             </td>
         </tr>
         {{ end }}

--- a/testdata/sequence_diagram_snapshot.html
+++ b/testdata/sequence_diagram_snapshot.html
@@ -36,7 +36,7 @@
         <tr>
             <th scope="row">1</th>
             <td>
-<pre>GET http://example.com/abcdef HTTP/1.1
+<pre>GET http://example.com/abcdef?name=abc HTTP/1.1
 Content-Type: application/json
 
 </pre>
@@ -48,7 +48,7 @@ Content-Type: application/json
             <th scope="row">2</th>
             <td>
 <pre>A</pre>
-<pre><code>B</code></pre>
+<pre style="max-height: 1000px;"><code>B</code></pre>
             </td>
         </tr>
         
@@ -56,7 +56,7 @@ Content-Type: application/json
             <th scope="row">3</th>
             <td>
 <pre>C</pre>
-<pre><code>D</code></pre>
+<pre style="max-height: 1000px;"><code>D</code></pre>
             </td>
         </tr>
         
@@ -74,7 +74,7 @@ Content-Type: application/json
     </table>
 </div>
 <script>
-    Diagram.parse("reqSource-\x3ereqTarget: (1) GET http:\/\/example.com\/abcdef\nmesReqSource-\x3e: (2) A\nmesResSource-\x3e\x3e: (3) C\nresSource-\x3e\x3eresTarget: (4) 204\n").drawSVG("d", {theme: 'simple', 'font-size': 14});
+    Diagram.parse("reqSource-\x3ereqTarget: (1) GET \/abcdef?name=abc\nmesReqSource-\x3e: (2) A\nmesResSource-\x3e\x3e: (3) C\nresSource-\x3e\x3eresTarget: (4) 204\n").drawSVG("d", {theme: 'simple', 'font-size': 14});
 </script>
 <style>
     body {


### PR DESCRIPTION
This allows more content to fit on the diagram links. The host is already visible from the block element