### PR TITLE
Add remove addr to clone of a request

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -959,6 +959,7 @@ func copyHttpRequest(request *http.Request) *http.Request {
 		ProtoMinor:    request.ProtoMinor,
 		ProtoMajor:    request.ProtoMajor,
 		ContentLength: request.ContentLength,
+		RemoteAddr:    request.RemoteAddr,
 	}
 
 	if request.Body != nil {


### PR DESCRIPTION
When we try to simulate client IP during out scenarios, the remote addrs is lost. This PR fixes that