### PR TITLE
Fix vet issue with copying mutex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 test:
 	bash -c 'diff -u <(echo -n) <(gofmt -s -d ./)'
-	bash -c 'diff -u <(echo -n) <(go vet ./...)'
+	go vet ./...
 	go test ./... -v -covermode=atomic -coverprofile=coverage.out
 
 test-examples:

--- a/apitest.go
+++ b/apitest.go
@@ -149,8 +149,7 @@ func (a *APITest) Mocks(mocks ...*Mock) *APITest {
 	for i := range mocks {
 		times := mocks[i].response.mock.times
 		for j := 1; j <= times; j++ {
-			mockCopy := *mocks[i]
-			m = append(m, &mockCopy)
+			m = append(m, mocks[i].copy())
 		}
 	}
 	a.mocks = m


### PR DESCRIPTION
I'm thinking this probably needs some more discussion @steinfletcher, but I thought I'd submit it for you to take a look.

`make test` was outputting a vet error but was swallowing it up. This PR fixes that issue and fixes `make test` to error when vet fails.

The issue reported by vet was:
```
./apitest.go:152:16: assignment copies lock value to mockCopy: github.com/steinfletcher/apitest.Mock contains sync.Mutex
```

This happens because we copy *Mock for each time we expect it to be called in a mock, and copy the mutex along with it. Vet regards this as a problem as it is a common way that sync.Mutex is misused. In the apitest scenario it works as expected, however, I have changed it to silence vet (it also reduces the chance that this causes a bug down the line). To fix, I have changed the Mock struct to contain a pointer to sync.Mutex instead. This causes a further issue:

* We have to create a new mutex when we copy, otherwise the copies of Mock share the same sync.Mutex - which I guess could cause its own issues (Perhaps they should share one mutex possibly - thoughts?). I have implemented this by adding a private copy() method on *Mock

There was another issue I spotted while looking into this inside the matching lock where we were doing `defer blah.Unlock()` inside a for loop, I have fixed this too.