### PR TITLE
copy http request body when networking is enabled

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -738,7 +738,7 @@ func (a *APITest) doRequest() (*http.Response, *http.Request) {
 		a.serveHttp(resRecorder, copyHttpRequest(req))
 		res = resRecorder.Result()
 	} else {
-		res, err = a.networkingHTTPClient.Do(req)
+		res, err = a.networkingHTTPClient.Do(copyHttpRequest(req))
 		if err != nil {
 			a.t.Fatal(err)
 		}


### PR DESCRIPTION
If you try to generate a sequence diagram with networking enabled instead of providing a handler, the request body isn't recorded. 

Using a Handler:
![image](https://user-images.githubusercontent.com/10819486/81609755-0bc81800-939e-11ea-989a-b8173d779117.png)

Pre-Fix:
![image](https://user-images.githubusercontent.com/10819486/81609786-184c7080-939e-11ea-9953-b5f8f1392475.png)

Post-Fix:
![image](https://user-images.githubusercontent.com/10819486/81609815-226e6f00-939e-11ea-833e-1c7512badbc9.png)

Sorry for the lack of tests, I'm not sure how to write them without generating several sequence diagrams and I didn't see anywhere y'all were doing that.