### PR TITLE
Remove unnecessary error envelope in test output when custom asserts …

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -399,18 +399,16 @@ func (r *Request) Expect(t *testing.T) *Response {
 
 // Response is the user defined expected response from the application under test
 type Response struct {
-	status             int
-	body               string
-	headers            map[string][]string
-	headersPresent     []string
-	headersNotPresent  []string
-	cookies            []*Cookie
-	cookiesPresent     []string
-	cookiesNotPresent  []string
-	jsonPathExpression string
-	jsonPathAssert     func(interface{})
-	apiTest            *APITest
-	assert             []Assert
+	status            int
+	body              string
+	headers           map[string][]string
+	headersPresent    []string
+	headersNotPresent []string
+	cookies           []*Cookie
+	cookiesPresent    []string
+	cookiesNotPresent []string
+	apiTest           *APITest
+	assert            []Assert
 }
 
 // Assert is a user defined custom assertion function
@@ -712,7 +710,7 @@ func (a *APITest) assertFunc(res *http.Response, req *http.Request) {
 		for _, assertFn := range a.response.assert {
 			err := assertFn(copyHttpResponse(res), copyHttpRequest(req))
 			if err != nil {
-				a.verifier.Equal(a.t, nil, err)
+				a.verifier.NoError(a.t, err)
 			}
 		}
 	}

--- a/assert.go
+++ b/assert.go
@@ -13,6 +13,7 @@ type Verifier interface {
 	Equal(t *testing.T, expected, actual interface{}, msgAndArgs ...interface{}) bool
 	JSONEq(t *testing.T, expected string, actual string, msgAndArgs ...interface{}) bool
 	Fail(t *testing.T, failureMessage string, msgAndArgs ...interface{}) bool
+	NoError(t *testing.T, err error, msgAndArgs ...interface{}) bool
 }
 
 // testifyVerifier is a verifier that use https://github.com/stretchr/testify to perform assertions
@@ -31,6 +32,11 @@ func (a testifyVerifier) Equal(t *testing.T, expected, actual interface{}, msgAn
 // Fail reports a failure
 func (a testifyVerifier) Fail(t *testing.T, failureMessage string, msgAndArgs ...interface{}) bool {
 	return assert.Fail(t, failureMessage, msgAndArgs...)
+}
+
+// NoError asserts that a function returned no error
+func (a testifyVerifier) NoError(t *testing.T, err error, msgAndArgs ...interface{}) bool {
+	return assert.NoError(t, err, msgAndArgs...)
 }
 
 func newTestifyVerifier() Verifier {
@@ -54,6 +60,11 @@ func (n NoopVerifier) JSONEq(t *testing.T, expected string, actual string, msgAn
 
 // Fail does not perform any assertion and always returns true
 func (n NoopVerifier) Fail(t *testing.T, failureMessage string, msgAndArgs ...interface{}) bool {
+	return true
+}
+
+// NoError asserts that a function returned no error
+func (n NoopVerifier) NoError(t *testing.T, err error, msgAndArgs ...interface{}) bool {
 	return true
 }
 

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -166,6 +166,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
@@ -239,3 +240,4 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -4,16 +4,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mocks/verifier.go
+++ b/mocks/verifier.go
@@ -17,6 +17,9 @@ type MockVerifier struct {
 
 	FailFn      func(t *testing.T, failureMessage string, msgAndArgs ...interface{}) bool
 	FailInvoked bool
+
+	NoErrorFn      func(t *testing.T, err error, msgAndArgs ...interface{}) bool
+	NoErrorInvoked bool
 }
 
 func NewVerifier() MockVerifier {
@@ -28,6 +31,9 @@ func NewVerifier() MockVerifier {
 			return true
 		},
 		FailFn: func(t *testing.T, failureMessage string, msgAndArgs ...interface{}) bool {
+			return true
+		},
+		NoErrorFn: func(t *testing.T, err error, msgAndArgs ...interface{}) bool {
 			return true
 		},
 	}
@@ -49,4 +55,10 @@ func (m MockVerifier) JSONEq(t *testing.T, expected string, actual string, msgAn
 func (m MockVerifier) Fail(t *testing.T, failureMessage string, msgAndArgs ...interface{}) bool {
 	m.FailInvoked = true
 	return m.FailFn(t, failureMessage, msgAndArgs)
+}
+
+// NoError asserts that a function returned no error
+func (m MockVerifier) NoError(t *testing.T, err error, msgAndArgs ...interface{}) bool {
+	m.NoErrorInvoked = true
+	return m.NoErrorFn(t, err, msgAndArgs)
 }


### PR DESCRIPTION
…fail

Instead of

expected: <nil>(nil)
actual: *errors.errorString(&errors.errorString{s:"my error"})

we will now print

Received unexpected error: "my error"