### PR TITLE
Add helpers to simplify making graphql requests

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -322,6 +322,40 @@ func (r *Request) JSONFromFile(f string) *Request {
 	return r
 }
 
+// GraphQLQuery is a convenience method for building a graphql POST request
+func (r *Request) GraphQLQuery(query string, variables ...map[string]interface{}) *Request {
+	q := GraphQLRequestBody{
+		Query: query,
+	}
+
+	if len(variables) > 0 {
+		q.Variables = variables[0]
+	}
+
+	return r.GraphQLRequest(q)
+}
+
+// GraphQLRequest builds a graphql POST request
+func (r *Request) GraphQLRequest(body GraphQLRequestBody) *Request {
+	r.ContentType("application/json")
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		r.apiTest.t.Fatal(err)
+	}
+
+	r.body = string(data)
+
+	return r
+}
+
+// GraphQLRequestBody represents the POST request body as per the GraphQL spec
+type GraphQLRequestBody struct {
+	Query         string                 `json:"query"`
+	Variables     map[string]interface{} `json:"variables,omitempty"`
+	OperationName string                 `json:"operationName,omitempty"`
+}
+
 // Query is a convenience method to add a query parameter to the request.
 func (r *Request) Query(key, value string) *Request {
 	r.query[key] = append(r.query[key], value)

--- a/docs/content/docs/request.md
+++ b/docs/content/docs/request.md
@@ -137,6 +137,11 @@ Body("<html>content</html>").
 Header("Content-Type", "text/html")
 ```
 
+## GraphQL
+
+The following helpers are provided to simplify building GraphQL requests.
+
+
 ## Basic auth
 
 A helper method is provided to add preemptive basic authentication to the request. 

--- a/examples/graphql/api_test.go
+++ b/examples/graphql/api_test.go
@@ -12,7 +12,15 @@ func TestQuery_Empty(t *testing.T) {
 	apitest.New().
 		Handler(graph.NewHandler()).
 		Post("/query").
-		JSON(`{"query": "query { todos { text done user { name } } }"}`).
+		GraphQLQuery(`query {
+			todos {
+				text
+				done
+				user {
+					name
+				}
+			}
+		}`).
 		Expect(t).
 		Status(http.StatusOK).
 		Body(`{
@@ -38,7 +46,7 @@ func TestQuery_WithTodo(t *testing.T) {
 	apitest.New().
 		Handler(handler).
 		Post("/query").
-		JSON(`{"query": "query { todos { text done user { name } } }"}`).
+		GraphQLQuery("query { todos { text done user { name } } }").
 		Expect(t).
 		Status(http.StatusOK).
 		Body(`{


### PR DESCRIPTION
With a standard graphql request you end up with graphql embedded within a json payload - making it difficult to build queries and do proper escaping in tests/client code. The change allows the user to pass a valid GraphQL query into the test, which means we can now use inject language fragments in IDEs for proper syntax highlighting. 