### PR TITLE
fixed README Assert example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ func TestApi(t *testing.T) {
 		Handler(handler).
 		Get("/hello").
 		Expect(t).
-		Assert(func(res *http.Response, req *http.Request) {
+		Assert(func(res *http.Response, req *http.Request) error {
 			assert.Equal(t, http.StatusOK, res.StatusCode)
+			return nil
 		}).
 		End()
 }


### PR DESCRIPTION
Hi, thanks for the lib, it's really coming in handy. Small error in the README example for Assert(), it needs to return an error to be valid. I kept the assert but the following would also work based on your taste:
```
if res.StatusCode != http.StatusOK {
	return fmt.Errorf("Incorrect status code, expected %v, got %v", http.StatusOK, res.StatusCode)
}
return nil
```

Thanks