### PR TITLE
Display mismatched values in assertion error when expected response h…

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -955,16 +955,19 @@ func (a *APITest) assertCookies(response *http.Response) {
 
 func (a *APITest) assertHeaders(res *http.Response) {
 	for expectedHeader, expectedValues := range a.response.headers {
-		for _, expectedValue := range expectedValues {
-			found := false
-			for _, resValue := range res.Header[expectedHeader] {
-				if expectedValue == resValue {
-					found = true
-					break
+		resHeaderValues, foundHeader := res.Header[expectedHeader]
+		a.verifier.Equal(a.t, true, foundHeader, fmt.Sprintf("expected header '%s' not present in response", expectedHeader))
+
+		if foundHeader {
+			for _, expectedValue := range expectedValues {
+				foundValue := false
+				for _, resValue := range resHeaderValues {
+					if expectedValue == resValue {
+						foundValue = true
+						break
+					}
 				}
-			}
-			if !found {
-				a.t.Fatalf("could not match header=%s", expectedHeader)
+				a.verifier.Equal(a.t, true, foundValue, fmt.Sprintf("mismatched values for header '%s'. Expected %s but received %s", expectedHeader, expectedValue, strings.Join(resHeaderValues, ",")))
 			}
 		}
 	}


### PR DESCRIPTION
…eader value doesn't match with received response headers

Hey, following up from https://github.com/steinfletcher/apitest/issues/97 I've updated the `assertHeaders()` method to make the assertion error a little bit more clear

Example:
```go
func TestApiTest_MatchesResponseHeaders_WithMixedKeyCase(t *testing.T) {
	handler := http.NewServeMux()
	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
		w.Header().Set("ABC", "12345")
		w.Header().Set("DEF", "67890")
		w.Header().Set("Authorization", "12345")
		w.Header().Add("authorizATION", "00000")
		w.Header().Add("Authorization", "98765")
		w.WriteHeader(http.StatusOK)
	})

	apitest.New().
		Handler(handler).
		Get("/hello").
		Expect(t).
		Status(http.StatusOK).
		Headers(map[string]string{
			"Abc": "12345",
			"Def": "67890",
		}).
		Header("My-Header", "123"). // header doesn't exist
		Header("Authorization", "123456"). // value doesn't match
		Header("Authorization", "00000").
		Header("authorization", "98765").
		HeaderPresent("Def").
		HeaderPresent("Authorization").
		HeaderNotPresent("XYZ").
		End()
}
```

```
 TestApiTest_MatchesResponseHeaders_WithMixedKeyCase: assert.go:29: 
                Error Trace:    assert.go:29
                                                        apitest.go:959
                                                        apitest.go:749
                                                        apitest.go:556
                                                        apitest_test.go:624
                Error:          Not equal: 
                                expected: true
                                actual  : false
                Test:           TestApiTest_MatchesResponseHeaders_WithMixedKeyCase
                Messages:       expected header 'My-Header' not present in response
    TestApiTest_MatchesResponseHeaders_WithMixedKeyCase: assert.go:29: 
                Error Trace:    assert.go:29
                                                        apitest.go:970
                                                        apitest.go:749
                                                        apitest.go:556
                                                        apitest_test.go:624
                Error:          Not equal: 
                                expected: true
                                actual  : false
                Test:           TestApiTest_MatchesResponseHeaders_WithMixedKeyCase
                Messages:       mismatched values for header 'Authorization'. Expected 123456 but received 12345,00000,98765

```