### PR TITLE
Preserve request context modified by interceptor

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -1069,6 +1069,7 @@ func copyHttpRequest(request *http.Request) *http.Request {
 		ContentLength: request.ContentLength,
 		RemoteAddr:    request.RemoteAddr,
 	}
+	resCopy = resCopy.WithContext(request.Context())
 
 	if request.Body != nil {
 		bodyBytes, _ := ioutil.ReadAll(request.Body)


### PR DESCRIPTION
I ran into a bit of unexpected behavior when I tried to inject some context values into the request and was surprised that they were missing :smile: 

This new behavior allows for injecting values into the context - very useful during testing!

Thoughts?