### PR TITLE
Support delaying mock responses by a fixed number of milliseconds

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -30,26 +30,27 @@ var responseDebugPrefix = fmt.Sprintf("<%s", divider)
 
 // APITest is the top level struct holding the test spec
 type APITest struct {
-	debugEnabled         bool
-	networkingEnabled    bool
-	networkingHTTPClient *http.Client
-	reporter             ReportFormatter
-	verifier             Verifier
-	recorder             *Recorder
-	handler              http.Handler
-	name                 string
-	request              *Request
-	response             *Response
-	observers            []Observe
-	mocksObservers       []Observe
-	recorderHook         RecorderHook
-	mocks                []*Mock
-	t                    *testing.T
-	httpClient           *http.Client
-	transport            *Transport
-	meta                 map[string]interface{}
-	started              time.Time
-	finished             time.Time
+	debugEnabled             bool
+	mockResponseDelayEnabled bool
+	networkingEnabled        bool
+	networkingHTTPClient     *http.Client
+	reporter                 ReportFormatter
+	verifier                 Verifier
+	recorder                 *Recorder
+	handler                  http.Handler
+	name                     string
+	request                  *Request
+	response                 *Response
+	observers                []Observe
+	mocksObservers           []Observe
+	recorderHook             RecorderHook
+	mocks                    []*Mock
+	t                        *testing.T
+	httpClient               *http.Client
+	transport                *Transport
+	meta                     map[string]interface{}
+	started                  time.Time
+	finished                 time.Time
 }
 
 // InboundRequest used to wrap the incoming request with a timestamp
@@ -104,6 +105,12 @@ func (a *APITest) EnableNetworking(cli ...*http.Client) *APITest {
 		return a
 	}
 	a.networkingHTTPClient = http.DefaultClient
+	return a
+}
+
+// EnableMockResponseDelay turns on mock response delays (defaults to OFF)
+func (a *APITest) EnableMockResponseDelay() *APITest {
+	a.mockResponseDelayEnabled = true
 	return a
 }
 
@@ -761,6 +768,7 @@ func (r *Response) runTest() *http.Response {
 			a.mocks,
 			a.httpClient,
 			a.debugEnabled,
+			a.mockResponseDelayEnabled,
 			a.mocksObservers,
 			r.apiTest,
 		)

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/microcosm-cc/bluemonday v1.0.2 // indirect
-	github.com/mitchellh/mapstructure v1.3.3
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/moul/http2curl v1.0.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -214,8 +214,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -1104,6 +1104,7 @@ func TestMocks_ApiTest_WithMocks(t *testing.T) {
 				Get("/user").
 				RespondWith().
 				Body(`{"name": "jon", "id": "1234"}`).
+				FixedDelay(5000).
 				Status(http.StatusOK).
 				End()
 
@@ -1194,10 +1195,12 @@ func TestMocks_ApiTest_SupportsObservingMocksWithReport(t *testing.T) {
 		RespondWith().
 		Status(http.StatusOK).
 		Body("2").
+		FixedDelay(1000).
 		End()
 
 	New().
 		Report(reporter).
+		EnableMockResponseDelay().
 		ObserveMocks(func(res *http.Response, req *http.Request, a *APITest) {
 			observeMocksCalled = true
 			if res == nil || req == nil || a == nil {
@@ -1228,6 +1231,8 @@ func TestMocks_ApiTest_SupportsObservingMocksWithReport(t *testing.T) {
 
 	assert.Equal(t, 3, len(observedMocks))
 	assert.True(t, observeMocksCalled)
+	oneSecondInNanoSecs := int64(1000000000)
+	assert.Greater(t, reporter.capturedRecorder.Meta["duration"], oneSecondInNanoSecs)
 }
 
 func TestMocks_ApiTest_SupportsMultipleMocks(t *testing.T) {


### PR DESCRIPTION
This feature might be useful for predicting the response time
of a handler. When using the Debug(...) helper the total time of the handler
is printed to the console. It might be desirable to only use this during
experiments and to not run this config in CI. This is why the global
option must be enabled to turn this on.