### PR TITLE
Support wrapping an existing database connector with a Recorder

### DIFF
--- a/x/db/db.go
+++ b/x/db/db.go
@@ -28,7 +28,7 @@ func WrapWithRecorder(driverName string, recorder *apitest.Recorder) driver.Driv
 	return recordingDriver
 }
 
-// WrapConnWithRecorder wraps an existing connector with a Recorder
+// WrapConnectorWithRecorder wraps an existing connector with a Recorder
 func WrapConnectorWithRecorder(connector driver.Connector, sourceName string, recorder *apitest.Recorder) driver.Connector {
 	return &recordingConnector{recorder: recorder, sourceName: sourceName, Connector: connector}
 }

--- a/x/db/db.go
+++ b/x/db/db.go
@@ -28,6 +28,11 @@ func WrapWithRecorder(driverName string, recorder *apitest.Recorder) driver.Driv
 	return recordingDriver
 }
 
+// WrapConnWithRecorder wraps an existing connector with a Recorder
+func WrapConnectorWithRecorder(connector driver.Connector, sourceName string, recorder *apitest.Recorder) driver.Connector {
+	return &recordingConnector{recorder: recorder, sourceName: sourceName, Connector: connector}
+}
+
 type recordingDriver struct {
 	Driver     driver.Driver
 	recorder   *apitest.Recorder


### PR DESCRIPTION
# Support wrapping an existing database connector with a Recorder

This might be useful when `apitest/x/db` is used with other instrumentation libraries.