### PR TITLE
Always Show HTTP Request Method in Sequence Diagrams

### DIFF
--- a/diagram.go
+++ b/diagram.go
@@ -155,9 +155,9 @@ var templateFunc = &htmlTemplate.FuncMap{
 }
 
 func formatDiagramRequest(req *http.Request) string {
-	out := req.URL.Path
+	out := fmt.Sprintf("%s %s", req.Method, req.URL.Path)
 	if req.URL.RawQuery != "" {
-		out = fmt.Sprintf("%s %s?%s", req.Method, out, req.URL.RawQuery)
+		out = fmt.Sprintf("%s?%s", out, req.URL.RawQuery)
 	}
 	if len(out) > 65 {
 		return fmt.Sprintf("%s...", out[:65])


### PR DESCRIPTION
Currently, the HTTP request method is only shown in sequence diagrams if there are query parameters set.

I think the HTTP request method should always be shown, regardless if there are query parameters or not.