### PR TITLE
Refactoring: Remove io/ioutil package (remove deprecated method).

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -354,7 +353,7 @@ func (r *Request) Bodyf(format string, args ...interface{}) *Request {
 
 // BodyFromFile is a builder method to set the request body
 func (r *Request) BodyFromFile(f string) *Request {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		r.apiTest.t.Fatal(err)
 	}
@@ -597,7 +596,7 @@ func (r *Response) Bodyf(format string, args ...interface{}) *Response {
 
 // BodyFromFile reads the given file and uses the content as the expected response body
 func (r *Response) BodyFromFile(f string) *Response {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		r.apiTest.t.Fatal(err)
 	}
@@ -724,7 +723,7 @@ func (r Result) UnmatchedMocks() []UnmatchedMock {
 
 // JSON unmarshal the result response body to a valid struct
 func (r Result) JSON(t interface{}) {
-	data, err := ioutil.ReadAll(r.Response.Body)
+	data, err := io.ReadAll(r.Response.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -1058,8 +1057,8 @@ func (a *APITest) assertResponse(res *http.Response) {
 	if a.response.body != "" {
 		var resBodyBytes []byte
 		if res.Body != nil {
-			resBodyBytes, _ = ioutil.ReadAll(res.Body)
-			res.Body = ioutil.NopCloser(bytes.NewBuffer(resBodyBytes))
+			resBodyBytes, _ = io.ReadAll(res.Body)
+			res.Body = io.NopCloser(bytes.NewBuffer(resBodyBytes))
 		}
 		if json.Valid([]byte(a.response.body)) {
 			a.verifier.JSONEq(a.t, a.response.body, string(resBodyBytes), failureMessageArgs{Name: a.name})
@@ -1158,15 +1157,15 @@ func copyHttpResponse(response *http.Response) *http.Response {
 
 	var resBodyBytes []byte
 	if response.Body != nil {
-		resBodyBytes, _ = ioutil.ReadAll(response.Body)
-		response.Body = ioutil.NopCloser(bytes.NewBuffer(resBodyBytes))
+		resBodyBytes, _ = io.ReadAll(response.Body)
+		response.Body = io.NopCloser(bytes.NewBuffer(resBodyBytes))
 	}
 
 	resCopy := &http.Response{
 		Header:        map[string][]string{},
 		StatusCode:    response.StatusCode,
 		Status:        response.Status,
-		Body:          ioutil.NopCloser(bytes.NewBuffer(resBodyBytes)),
+		Body:          io.NopCloser(bytes.NewBuffer(resBodyBytes)),
 		Proto:         response.Proto,
 		ProtoMinor:    response.ProtoMinor,
 		ProtoMajor:    response.ProtoMajor,
@@ -1193,9 +1192,9 @@ func copyHttpRequest(request *http.Request) *http.Request {
 	resCopy = resCopy.WithContext(request.Context())
 
 	if request.Body != nil {
-		bodyBytes, _ := ioutil.ReadAll(request.Body)
-		resCopy.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
-		request.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		bodyBytes, _ := io.ReadAll(request.Body)
+		resCopy.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}
 
 	if request.URL != nil {

--- a/apitest_test.go
+++ b/apitest_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -34,7 +34,7 @@ func TestApiTest_ResponseBody(t *testing.T) {
 func TestApiTest_HttpRequest(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		if string(data) != `hello` {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -58,7 +58,7 @@ func TestApiTest_HttpRequest(t *testing.T) {
 func TestApiTest_AddsJSONBodyToRequest(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		if string(data) != `{"a": 12345}` {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -82,7 +82,7 @@ func TestApiTest_AddsJSONBodyToRequest(t *testing.T) {
 func TestApiTest_AddsJSONBodyToRequest_SupportsFormatter(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		if string(data) != `{"a": 12345}` {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -192,7 +192,7 @@ func TestApiTest_JSONBody(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			handler := http.NewServeMux()
 			handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-				data, _ := ioutil.ReadAll(r.Body)
+				data, _ := io.ReadAll(r.Body)
 				assert.JSONEq(t, `{"a": 12345}`, string(data))
 				if r.Header.Get("Content-Type") != "application/json" {
 					w.WriteHeader(http.StatusBadRequest)
@@ -215,7 +215,7 @@ func TestApiTest_JSONBody(t *testing.T) {
 func TestApiTest_AddsJSONBodyToRequestUsingJSON(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		if string(data) != `{"a": 12345}` {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -239,7 +239,7 @@ func TestApiTest_AddsJSONBodyToRequestUsingJSON(t *testing.T) {
 func TestApiTest_AddsTextBodyToRequest(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		if string(data) != `hello` {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -476,7 +476,7 @@ func TestApiTest_AddsCancelledContextToRequest(t *testing.T) {
 func TestApiTest_GraphQLQuery(t *testing.T) {
 	apitest.New().
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			bodyBytes, err := ioutil.ReadAll(r.Body)
+			bodyBytes, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -502,7 +502,7 @@ func TestApiTest_GraphQLQuery(t *testing.T) {
 func TestApiTest_GraphQLRequest(t *testing.T) {
 	apitest.New().
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			bodyBytes, err := ioutil.ReadAll(r.Body)
+			bodyBytes, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -582,7 +582,7 @@ func TestApiTest_MatchesJSONResponseBodyWithFormatter(t *testing.T) {
 func TestApiTest_MatchesJSONBodyFromFile(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		assert.JSONEq(t, `{"a": 12345}`, string(data))
 
 		w.WriteHeader(http.StatusCreated)
@@ -606,7 +606,7 @@ func TestApiTest_MatchesJSONBodyFromFile(t *testing.T) {
 func TestApiTest_MatchesBodyFromFile(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		assert.JSONEq(t, `{"a": 12345}`, string(data))
 
 		w.WriteHeader(http.StatusCreated)
@@ -1259,7 +1259,7 @@ func TestApiTest_AddsMultipartFormData(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				data, err := ioutil.ReadAll(f)
+				data, err := io.ReadAll(f)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1386,7 +1386,7 @@ func getUserData() []byte {
 	if err != nil {
 		panic(err)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/diagram.go
+++ b/diagram.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	htmlTemplate "html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -266,12 +265,12 @@ func formatBodyContent(bodyReadCloser io.ReadCloser, replaceBody func(replacemen
 		return "", nil
 	}
 
-	body, err := ioutil.ReadAll(bodyReadCloser)
+	body, err := io.ReadAll(bodyReadCloser)
 	if err != nil {
 		return "", err
 	}
 
-	replaceBody(ioutil.NopCloser(bytes.NewReader(body)))
+	replaceBody(io.NopCloser(bytes.NewReader(body)))
 
 	buf := new(bytes.Buffer)
 	if json.Valid(body) {

--- a/diagram_test.go
+++ b/diagram_test.go
@@ -3,7 +3,6 @@ package apitest
 import (
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -30,7 +29,7 @@ func TestDiagram_BadgeCSSClass(t *testing.T) {
 }
 
 func TestFormatBodyContent_ShouldReplaceBody(t *testing.T) {
-	stream := ioutil.NopCloser(strings.NewReader("lol"))
+	stream := io.NopCloser(strings.NewReader("lol"))
 
 	val, err := formatBodyContent(stream, func(replacementBody io.ReadCloser) {
 		stream = replacementBody
@@ -150,7 +149,7 @@ func TestNewHttpResponseLogEntry_JSON(t *testing.T) {
 		ProtoMinor:    1,
 		StatusCode:    http.StatusOK,
 		ContentLength: 21,
-		Body:          ioutil.NopCloser(strings.NewReader(`{"a": 12345}`)),
+		Body:          io.NopCloser(strings.NewReader(`{"a": 12345}`)),
 	}
 
 	logEntry, err := newHTTPResponseLogEntry(response)
@@ -167,7 +166,7 @@ func TestNewHttpResponseLogEntry_PlainText(t *testing.T) {
 		ProtoMinor:    1,
 		StatusCode:    http.StatusOK,
 		ContentLength: 21,
-		Body:          ioutil.NopCloser(strings.NewReader(`abcdef`)),
+		Body:          io.NopCloser(strings.NewReader(`abcdef`)),
 	}
 
 	logEntry, err := newHTTPResponseLogEntry(response)
@@ -205,7 +204,7 @@ type FS struct {
 
 func (m *FS) create(name string) (*os.File, error) {
 	m.CapturedCreateName = name
-	file, err := ioutil.TempFile("/tmp", "apitest")
+	file, err := os.CreateTemp("/tmp", "apitest")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/mocks/server.go
+++ b/examples/mocks/server.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -69,7 +69,7 @@ func get(path string, response interface{}) {
 		panic(err)
 	}
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/sequence-diagrams-with-mysql-database/server.go
+++ b/examples/sequence-diagrams-with-mysql-database/server.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -79,7 +79,7 @@ func getUser(db *sqlx.DB) http.HandlerFunc {
 func postUser(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var user user
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}
@@ -131,7 +131,7 @@ func get(path string, response interface{}) {
 		panic(fmt.Sprintf("unexpected status code=%d", res.StatusCode))
 	}
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/sequence-diagrams-with-postgres-database/server.go
+++ b/examples/sequence-diagrams-with-postgres-database/server.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -74,7 +74,7 @@ func getUser(db *sqlx.DB) http.HandlerFunc {
 func postUser(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var user user
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}
@@ -124,7 +124,7 @@ func get(path string, response interface{}) {
 		panic(fmt.Sprintf("unexpected status code=%d", res.StatusCode))
 	}
 
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/sequence-diagrams-with-sqlite-database/server.go
+++ b/examples/sequence-diagrams-with-sqlite-database/server.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -77,7 +77,7 @@ func getUser(db *sqlx.DB) http.HandlerFunc {
 func postUser(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var user user
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}
@@ -127,7 +127,7 @@ func get(path string, response interface{}) {
 		panic(fmt.Sprintf("unexpected status code=%d", res.StatusCode))
 	}
 
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/sequence-diagrams/server.go
+++ b/examples/sequence-diagrams/server.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -73,7 +73,7 @@ func get(path string, response interface{}) {
 		panic(fmt.Sprintf("unexpected status code=%d", res.StatusCode))
 	}
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/mocks.go
+++ b/mocks.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/textproto"
 	"net/url"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -191,7 +192,7 @@ func buildResponseFromMock(mockResponse *MockResponse) *http.Response {
 	}
 
 	res := &http.Response{
-		Body:          ioutil.NopCloser(strings.NewReader(mockResponse.body)),
+		Body:          io.NopCloser(strings.NewReader(mockResponse.body)),
 		Header:        mockResponse.headers,
 		StatusCode:    mockResponse.statusCode,
 		ProtoMajor:    1,
@@ -486,7 +487,7 @@ func (r *MockRequest) Bodyf(format string, args ...interface{}) *MockRequest {
 
 // BodyFromFile configures the mock request to match the given body from a file
 func (r *MockRequest) BodyFromFile(f string) *MockRequest {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		panic(err)
 	}
@@ -673,7 +674,7 @@ func (r *MockResponse) Bodyf(format string, args ...interface{}) *MockResponse {
 
 // BodyFromFile defines the mock response body from a file
 func (r *MockResponse) BodyFromFile(f string) *MockResponse {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		panic(err)
 	}
@@ -1029,7 +1030,7 @@ var bodyMatcher = func(req *http.Request, spec *MockRequest) error {
 		return errors.New("expected a body but received none")
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return err
 	}
@@ -1038,7 +1039,7 @@ var bodyMatcher = func(req *http.Request, spec *MockRequest) error {
 	}
 
 	// replace body so it can be read again
-	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	req.Body = io.NopCloser(bytes.NewReader(body))
 
 	// Perform exact string match
 	bodyStr := string(body)
@@ -1076,7 +1077,7 @@ var bodyRegexpMatcher = func(req *http.Request, spec *MockRequest) error {
 		return errors.New("expected a body but received none")
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return err
 	}
@@ -1085,7 +1086,7 @@ var bodyRegexpMatcher = func(req *http.Request, spec *MockRequest) error {
 	}
 
 	// replace body so it can be read again
-	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	req.Body = io.NopCloser(bytes.NewReader(body))
 
 	// Perform regexp match
 	bodyStr := string(body)

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -972,7 +972,7 @@ func TestMocks_Response_SetsTextPlainIfNoContentTypeSet(t *testing.T) {
 
 	response := buildResponseFromMock(mockResponse)
 
-	bytes, _ := ioutil.ReadAll(response.Body)
+	bytes, _ := io.ReadAll(response.Body)
 	assert.Equal(t, string(bytes), "abcdef")
 	assert.Equal(t, "text/plain", response.Header.Get("Content-Type"))
 }
@@ -985,7 +985,7 @@ func TestMocks_Response_SetsTheBodyAsJSON(t *testing.T) {
 
 	response := buildResponseFromMock(mockResponse)
 
-	bytes, _ := ioutil.ReadAll(response.Body)
+	bytes, _ := io.ReadAll(response.Body)
 	assert.Equal(t, string(bytes), `{"a": 123}`)
 	assert.Equal(t, "application/json", response.Header.Get("Content-Type"))
 }
@@ -998,7 +998,7 @@ func TestMocks_ResponseJSON(t *testing.T) {
 
 	response := buildResponseFromMock(mockResponse)
 
-	bytes, _ := ioutil.ReadAll(response.Body)
+	bytes, _ := io.ReadAll(response.Body)
 	assert.Equal(t, string(bytes), `{"a":123}`)
 	assert.Equal(t, "application/json", response.Header.Get("Content-Type"))
 }
@@ -1012,7 +1012,7 @@ func TestMocks_Response_SetsTheBodyAsOther(t *testing.T) {
 
 	response := buildResponseFromMock(mockResponse)
 
-	bytes, _ := ioutil.ReadAll(response.Body)
+	bytes, _ := io.ReadAll(response.Body)
 	assert.Equal(t, string(bytes), `<html>123</html>`)
 	assert.Equal(t, "text/html", response.Header.Get("Content-Type"))
 }
@@ -1093,7 +1093,7 @@ func TestMocks_Standalone_WithContainer(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-	data, err := ioutil.ReadAll(getRes.Body)
+	data, err := io.ReadAll(getRes.Body)
 
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"a": 12345}`, string(data))
@@ -1327,7 +1327,7 @@ func getUserData() []byte {
 	if err != nil {
 		panic(err)
 	}
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -1384,7 +1384,7 @@ func NewHttpGet(cli *http.Client) HttpGet {
 			panic(err)
 		}
 
-		bytes, err := ioutil.ReadAll(res.Body)
+		bytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This PR is aimed at refactoring and does not include any functional changes. 

The io/ioutil package has been deprecated since Go 1.16. I have refactored the code to use alternative methods provided, in accordance with the deprecation.