### PR TITLE
feat(mocks): added support for reusing mocks any times

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ func TestApi(t *testing.T) {
 		End()
 }
 ```
+It is possible to configure the mock for using `AnyTimes` feature,  it allows a mock to be invoked any number of times 
+without failing the asserts if it is not used the expected number of times. 
+
+This is very useful in scenarios where the exact number of invocations is not known or not important.
+
+```go
+var getUser := apitest.NewMock().
+    Get("http://localhost:8080").
+    RespondWith().
+    Status(http.StatusOK).
+    AnyTimes().
+    End()
+```
+Note: The `AnyTimes` method can be combined with other methods such as `Times`, but if `AnyTimes` is set, the `Times` setting will have no effect.
 
 #### Generating sequence diagrams from tests
 

--- a/apitest.go
+++ b/apitest.go
@@ -895,7 +895,7 @@ func (r *Response) runTest() *http.Response {
 
 func (a *APITest) assertMocks() {
 	for _, mock := range a.mocks {
-		if mock.isUsed == false && mock.timesSet {
+		if mock.anyTimesSet == false && mock.isUsed == false && mock.timesSet {
 			a.verifier.Fail(a.t, "mock was not invoked expected times", failureMessageArgs{Name: a.name})
 		}
 	}

--- a/apitest.go
+++ b/apitest.go
@@ -169,6 +169,11 @@ func (a *APITest) HandlerFunc(handlerFunc http.HandlerFunc) *APITest {
 func (a *APITest) Mocks(mocks ...*Mock) *APITest {
 	var m []*Mock
 	for i := range mocks {
+		if mocks[i].anyTimesSet {
+			m = append(m, mocks[i])
+			continue
+		}
+
 		times := mocks[i].response.mock.times
 		for j := 1; j <= times; j++ {
 			mockCpy := mocks[i].copy()

--- a/apitest_test.go
+++ b/apitest_test.go
@@ -1378,6 +1378,7 @@ func TestApiTest_MatchesAnyTimes(t *testing.T) {
 		Get("http://localhost:8080").
 		RespondWith().
 		Status(http.StatusOK).
+		Times(2).
 		AnyTimes().
 		End()
 

--- a/apitest_test.go
+++ b/apitest_test.go
@@ -1373,6 +1373,31 @@ func TestApiTest_MatchesTimes(t *testing.T) {
 	assert.Equal(t, 0, len(res.UnmatchedMocks()))
 }
 
+func TestApiTest_MatchesAnyTimes(t *testing.T) {
+	getUser := apitest.NewMock().
+		Get("http://localhost:8080").
+		RespondWith().
+		Status(http.StatusOK).
+		AnyTimes().
+		End()
+
+	res := apitest.New().
+		Mocks(getUser).
+		Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Call getUserData() many times
+			_ = getUserData()
+			_ = getUserData()
+			_ = getUserData()
+			w.WriteHeader(http.StatusOK)
+		})).
+		Get("/").
+		Expect(t).
+		Status(http.StatusOK).
+		End()
+
+	assert.Equal(t, 0, len(res.UnmatchedMocks()))
+}
+
 type RecorderCaptor struct {
 	capturedRecorder apitest.Recorder
 }

--- a/mocks.go
+++ b/mocks.go
@@ -710,7 +710,7 @@ func (r *MockResponse) FixedDelay(delay int64) *MockResponse {
 	return r
 }
 
-// Times respond the given number of times
+// Times respond the given number of times, if AnyTimes is set this has no effect
 func (r *MockResponse) Times(times int) *MockResponse {
 	r.mock.times = times
 	r.mock.timesSet = true

--- a/mocks.go
+++ b/mocks.go
@@ -222,6 +222,7 @@ type Mock struct {
 	debugStandalone bool
 	times           int
 	timesSet        bool
+	anyTimesSet     bool
 }
 
 // Matches checks whether the given request matches the mock
@@ -448,7 +449,7 @@ func matches(req *http.Request, mocks []*Mock) (*MockResponse, error) {
 	mockError := newUnmatchedMockError()
 	for mockNumber, mock := range mocks {
 		mock.m.Lock() // lock is for isUsed when matches is called concurrently by RoundTripper
-		if mock.isUsed {
+		if mock.isUsed && mock.anyTimesSet == false {
 			mock.m.Unlock()
 			continue
 		}
@@ -713,6 +714,12 @@ func (r *MockResponse) FixedDelay(delay int64) *MockResponse {
 func (r *MockResponse) Times(times int) *MockResponse {
 	r.mock.times = times
 	r.mock.timesSet = true
+	return r
+}
+
+// AnyTimes respond any number of times
+func (r *MockResponse) AnyTimes() *MockResponse {
+	r.mock.anyTimesSet = true
 	return r
 }
 


### PR DESCRIPTION
#### Summary
The PR adds support for reusing mocks any number of times by introducing a new `AnyTimes` method. This method allows a mock to be invoked multiple times without failing the test if it is not used the expected number of times.

#### Motivation

This feature is very useful in scenarios where the exact number of invocations is not known or not important.

#### Changes
1. **`apitest.go`**:
   - Modified the `assertMocks` method to check for `anyTimesSet` before failing the test if the mock was not invoked the expected number of times.
   - Updated the `Mocks` method to handle mocks with `anyTimesSet`.

2. **`apitest_test.go`**:
   - Added a new test `TestApiTest_MatchesAnyTimes` to verify the functionality of the `AnyTimes` method.

3. **`mocks.go`**:
   - Added a new boolean field `anyTimesSet` to the `Mock` struct.
   - Modified the `matches` function to skip used mocks if `anyTimesSet` is true.
   - Added a new method `AnyTimes` to the `MockResponse` struct to set the `anyTimesSet` field.

4. **`README.md`**:
   - Updated the documentation to include usage instructions for the new `AnyTimes` method.