### PR TITLE
Added support for custom host

### DIFF
--- a/apitest.go
+++ b/apitest.go
@@ -292,10 +292,9 @@ func (a *APITest) Getf(format string, args ...interface{}) *Request {
 
 // Post is a convenience method for setting the request as http.MethodPost
 func (a *APITest) Post(url string) *Request {
-	r := a.request
-	r.method = http.MethodPost
-	r.url = url
-	return r
+	a.request.method = http.MethodPost
+	a.request.url = url
+	return a.request
 }
 
 // Postf is a convenience method that adds formatting support to Post
@@ -305,10 +304,9 @@ func (a *APITest) Postf(format string, args ...interface{}) *Request {
 
 // Put is a convenience method for setting the request as http.MethodPut
 func (a *APITest) Put(url string) *Request {
-	r := a.request
-	r.method = http.MethodPut
-	r.url = url
-	return r
+	a.request.method = http.MethodPut
+	a.request.url = url
+	return a.request
 }
 
 // Putf is a convenience method that adds formatting support to Put

--- a/apitest_test.go
+++ b/apitest_test.go
@@ -19,29 +19,19 @@ import (
 	"github.com/steinfletcher/apitest/mocks"
 )
 
-type subdomainContextType struct{}
-
-var subdomainContextKey = &subdomainContextType{}
-
-func ContextSubdomainInjector(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		host := strings.Split(r.Host, ".")
-		subdomain := host[0]
-		ctx := context.WithValue(r.Context(), subdomainContextKey, subdomain)
-		h.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
-
 func TestApiTest_CustomHost(t *testing.T) {
 	handler := http.NewServeMux()
-	handler.Handle("/hello", ContextSubdomainInjector(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		subdomain := r.Context().Value(subdomainContextKey)
+	handler.Handle("/hello", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := strings.Split(r.Host, ".")
+		subdomain := host[0]
+
 		if subdomain != "demo" {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+
 		w.WriteHeader(http.StatusOK)
-	})))
+	}))
 
 	apitest.New().
 		Handler(handler).


### PR DESCRIPTION
This PR makes it possible to customize the host on each request.
Like this:

```
	apitest.New().
		Handler(handler).
		Host("demo.example.com").
		Get("/hello").
		Expect(t).
		Status(http.StatusOK).
		End()
```

I added this to facilitate testing a solution where the subdomain slug is used as a key to retrieve data needed in the handler.